### PR TITLE
Add inline post detail dialog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,11 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import AuthProvider from "./context/AuthProvider";
 import Index from "./pages/Index";
+import Login from "./pages/Login";
+import Register from "./pages/Register";
+import PostDetail from "./pages/PostDetail";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -14,11 +18,19 @@ const App = () => (
       <Toaster />
       <Sonner />
       <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
+        <AuthProvider>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/register" element={<Register />} />
+            <Route
+              path="/boards/:boardId/posts/:postId"
+              element={<PostDetail />}
+            />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </AuthProvider>
       </BrowserRouter>
     </TooltipProvider>
   </QueryClientProvider>

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -36,8 +36,14 @@ const Chat = () => {
     const board = boards?.find((b) => b.id === activeBoard);
     if (!board) return;
     const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
-    const base = import.meta.env.VITE_WS_URL ?? `${scheme}://${window.location.host}/api/v1/ws`;
-    const ws = new WebSocket(`${base}/chat/${encodeURIComponent(board.name)}?username=${encodeURIComponent(username)}`);
+    const base =
+      import.meta.env.VITE_WS_URL ?? `${scheme}://${window.location.host}/api/v1/ws`;
+    const room = `board_id_${board.id}`;
+    const ws = new WebSocket(
+      `${base}/chat/${encodeURIComponent(room)}?username=${encodeURIComponent(
+        username,
+      )}`,
+    );
     wsRef.current = ws;
     ws.onmessage = (event) => {
       try {

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -41,7 +41,18 @@ const Chat = () => {
       } catch {
         // ignore JSON parse errors
       }
-      setMessages((prev) => [...prev, { username: 'server', message: event.data }]);
+      if (event.data.startsWith('server:')) {
+        setMessages((prev) => [...prev, { username: 'server', message: event.data.slice(7) }]);
+        return;
+      }
+      const idx = event.data.indexOf(':');
+      if (idx !== -1) {
+        const from = event.data.slice(0, idx).trim();
+        const msg = event.data.slice(idx + 1).trim();
+        setMessages((prev) => [...prev, { username: from, message: msg }]);
+      } else {
+        setMessages((prev) => [...prev, { username: 'server', message: event.data }]);
+      }
     };
     return () => {
       ws.close();
@@ -52,7 +63,6 @@ const Chat = () => {
     if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
     if (!input.trim()) return;
     wsRef.current.send(input);
-    setMessages((prev) => [...prev, { username, message: input }]);
     setInput('');
   };
 

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,0 +1,84 @@
+import { useContext, useEffect, useRef, useState } from 'react';
+import { AuthContext } from '@/context/AuthContext';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+
+interface ChatMessage {
+  username: string;
+  message: string;
+}
+
+function parseUsername(token: string | null): string | null {
+  if (!token) return null;
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    return payload.username || payload.sub || null;
+  } catch {
+    return null;
+  }
+}
+
+const Chat = () => {
+  const { accessToken } = useContext(AuthContext);
+  const username = parseUsername(accessToken) ?? 'guest';
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const wsRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const base = import.meta.env.VITE_WS_URL ?? `${scheme}://${window.location.host}/api/v1/ws`;
+    const ws = new WebSocket(`${base}/chat/general?username=${encodeURIComponent(username)}`);
+    wsRef.current = ws;
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (typeof data.username === 'string' && typeof data.message === 'string') {
+          setMessages((prev) => [...prev, data]);
+          return;
+        }
+      } catch {
+        // ignore JSON parse errors
+      }
+      setMessages((prev) => [...prev, { username: 'server', message: event.data }]);
+    };
+    return () => {
+      ws.close();
+    };
+  }, [username]);
+
+  const sendMessage = () => {
+    if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+    if (!input.trim()) return;
+    wsRef.current.send(input);
+    setMessages((prev) => [...prev, { username, message: input }]);
+    setInput('');
+  };
+
+  return (
+    <div className="flex flex-col h-full p-4 space-y-4">
+      <ScrollArea className="flex-1 pr-4">
+        <div className="space-y-2">
+          {messages.map((msg, idx) => (
+            <div key={idx} className="text-sm">
+              <span className="text-blue-400 mr-2">{msg.username}:</span>
+              <span>{msg.message}</span>
+            </div>
+          ))}
+        </div>
+      </ScrollArea>
+      <div className="flex space-x-2">
+        <Input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
+          placeholder="메시지를 입력하세요..."
+        />
+        <Button onClick={sendMessage}>전송</Button>
+      </div>
+    </div>
+  );
+};
+
+export default Chat;

--- a/src/components/CreatePostDialog.tsx
+++ b/src/components/CreatePostDialog.tsx
@@ -1,0 +1,117 @@
+import { useState, useContext } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import * as z from 'zod';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { toast } from '@/components/ui/sonner';
+import { createPost, CreatePostPayload } from '@/lib/api';
+import { AuthContext } from '@/context/AuthContext';
+
+const schema = z.object({
+  title: z.string().min(1, 'Enter title'),
+  content: z.string().min(1, 'Enter content'),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+interface Props {
+  boardId: number;
+}
+
+const CreatePostDialog = ({ boardId }: Props) => {
+  const [open, setOpen] = useState(false);
+  const { isAuthenticated, accessToken } = useContext(AuthContext);
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { title: '', content: '' },
+  });
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (values: FormValues) =>
+      createPost(
+        boardId,
+        { ...values, board_id: boardId } as CreatePostPayload,
+        accessToken ?? undefined,
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['posts', boardId] });
+      toast.success('Post created');
+      setOpen(false);
+      form.reset();
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const onSubmit = (values: FormValues) => mutation.mutate(values);
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="secondary">새 글 작성</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>새 글 작성</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Title</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="content"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Content</FormLabel>
+                  <FormControl>
+                    <Textarea rows={5} {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Button type="submit" className="w-full" disabled={mutation.isPending}>
+              {mutation.isPending ? 'Posting...' : 'Post'}
+            </Button>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CreatePostDialog;

--- a/src/components/CreatePostDialog.tsx
+++ b/src/components/CreatePostDialog.tsx
@@ -54,6 +54,7 @@ const CreatePostDialog = ({ boardId }: Props) => {
       ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['posts', boardId] });
+      queryClient.invalidateQueries({ queryKey: ['boards'] });
       toast.success('Post created');
       setOpen(false);
       form.reset();

--- a/src/components/PostDetailContent.tsx
+++ b/src/components/PostDetailContent.tsx
@@ -151,7 +151,11 @@ const PostDetailContent = ({ boardId, postId }: Props) => {
                   render={({ field }) => (
                     <FormItem>
                       <FormControl>
-                        <Textarea rows={3} {...field} />
+                        <Textarea
+                          rows={3}
+                          placeholder="새 댓글을 달아주세요!"
+                          {...field}
+                        />
                       </FormControl>
                       <FormMessage />
                     </FormItem>

--- a/src/components/PostDetailContent.tsx
+++ b/src/components/PostDetailContent.tsx
@@ -1,0 +1,79 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchPost, fetchComments } from '@/lib/api';
+
+interface Props {
+  boardId: number;
+  postId: number;
+}
+
+const PostDetailContent = ({ boardId, postId }: Props) => {
+  const postQuery = useQuery({
+    queryKey: ['post', boardId, postId],
+    queryFn: () => fetchPost(boardId, postId),
+  });
+
+  const commentsQuery = useQuery({
+    queryKey: ['comments', postId],
+    queryFn: () => fetchComments(postId),
+  });
+
+  const post = postQuery.data;
+  const comments = commentsQuery.data ?? [];
+
+  if (postQuery.isLoading) {
+    return <div className="p-6">Loading...</div>;
+  }
+
+  if (!post) {
+    return <div className="p-6">Post not found.</div>;
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="bg-gray-800 rounded-lg p-6">
+        <div className="mb-4">
+          <h1 className="text-2xl font-bold mb-2">{post.title}</h1>
+          <p className="text-sm text-gray-400">
+            {post.author.username} • {new Date(post.created_at).toLocaleString()}
+          </p>
+        </div>
+        <p className="whitespace-pre-wrap mb-4">{post.content}</p>
+        {post.files.length > 0 && (
+          <div className="space-y-2">
+            <h3 className="font-semibold">Attachments</h3>
+            <ul className="list-disc list-inside text-blue-400">
+              {post.files.map((file) => (
+                <li key={file.id}>
+                  <a
+                    href={`/api/v1/files/${file.id}/download`}
+                    className="hover:underline"
+                  >
+                    {file.filename ?? `File ${file.id}`}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+
+      <div className="bg-gray-800 rounded-lg p-6">
+        <h2 className="text-lg font-semibold mb-4">Comments</h2>
+        {commentsQuery.isLoading && <p>Loading comments...</p>}
+        {!commentsQuery.isLoading && comments.length === 0 && <p>No comments.</p>}
+        <div className="space-y-4">
+          {comments.map((c) => (
+            <div key={c.id} className="border-b border-gray-700 pb-2">
+              <p className="text-sm text-gray-400">
+                {c.author.username} • {new Date(c.created_at).toLocaleString()}
+              </p>
+              <p className="whitespace-pre-wrap mt-1">{c.content}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PostDetailContent;

--- a/src/components/PostDetailContent.tsx
+++ b/src/components/PostDetailContent.tsx
@@ -1,5 +1,15 @@
-import { useQuery } from '@tanstack/react-query';
-import { fetchPost, fetchComments } from '@/lib/api';
+import { useQuery } from "@tanstack/react-query";
+import { Paperclip } from "lucide-react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { fetchPost, fetchComments } from "@/lib/api";
 
 interface Props {
   boardId: number;
@@ -8,12 +18,12 @@ interface Props {
 
 const PostDetailContent = ({ boardId, postId }: Props) => {
   const postQuery = useQuery({
-    queryKey: ['post', boardId, postId],
+    queryKey: ["post", boardId, postId],
     queryFn: () => fetchPost(boardId, postId),
   });
 
   const commentsQuery = useQuery({
-    queryKey: ['comments', postId],
+    queryKey: ["comments", postId],
     queryFn: () => fetchComments(postId),
   });
 
@@ -29,49 +39,72 @@ const PostDetailContent = ({ boardId, postId }: Props) => {
   }
 
   return (
-    <div className="p-6 space-y-6">
-      <div className="bg-gray-800 rounded-lg p-6">
-        <div className="mb-4">
-          <h1 className="text-2xl font-bold mb-2">{post.title}</h1>
-          <p className="text-sm text-gray-400">
-            {post.author.username} • {new Date(post.created_at).toLocaleString()}
-          </p>
-        </div>
-        <p className="whitespace-pre-wrap mb-4">{post.content}</p>
-        {post.files.length > 0 && (
-          <div className="space-y-2">
-            <h3 className="font-semibold">Attachments</h3>
-            <ul className="list-disc list-inside text-blue-400">
-              {post.files.map((file) => (
-                <li key={file.id}>
-                  <a
-                    href={`/api/v1/files/${file.id}/download`}
-                    className="hover:underline"
-                  >
-                    {file.filename ?? `File ${file.id}`}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-      </div>
-
-      <div className="bg-gray-800 rounded-lg p-6">
-        <h2 className="text-lg font-semibold mb-4">Comments</h2>
-        {commentsQuery.isLoading && <p>Loading comments...</p>}
-        {!commentsQuery.isLoading && comments.length === 0 && <p>No comments.</p>}
-        <div className="space-y-4">
-          {comments.map((c) => (
-            <div key={c.id} className="border-b border-gray-700 pb-2">
-              <p className="text-sm text-gray-400">
-                {c.author.username} • {new Date(c.created_at).toLocaleString()}
-              </p>
-              <p className="whitespace-pre-wrap mt-1">{c.content}</p>
+    <div className="space-y-6 p-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>{post.title}</CardTitle>
+          <CardDescription>
+            {post.author.username} •{" "}
+            {new Date(post.created_at).toLocaleString()}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="whitespace-pre-wrap">{post.content}</p>
+          {post.files.length > 0 && (
+            <div className="space-y-2">
+              <h3 className="font-medium">Attachments</h3>
+              <ul className="space-y-1">
+                {post.files.map((file) => (
+                  <li key={file.id}>
+                    <a
+                      href={`/api/v1/files/${file.id}/download`}
+                      className="text-blue-400 hover:underline inline-flex items-center space-x-1"
+                    >
+                      <Paperclip className="w-4 h-4" />
+                      <span>{file.filename ?? `File ${file.id}`}</span>
+                    </a>
+                  </li>
+                ))}
+              </ul>
             </div>
-          ))}
-        </div>
-      </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Comments</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {commentsQuery.isLoading && <p>Loading comments...</p>}
+          {!commentsQuery.isLoading && comments.length === 0 && (
+            <p className="text-sm text-gray-400">No comments.</p>
+          )}
+          <ScrollArea className="max-h-72 space-y-4 pr-4">
+            {comments.map((c) => (
+              <div
+                key={c.id}
+                className="pb-2 border-b border-gray-700 last:border-none"
+              >
+                <div className="flex items-start space-x-3">
+                  <Avatar className="h-8 w-8">
+                    <AvatarFallback>
+                      {c.author.username.charAt(0).toUpperCase()}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="flex-1">
+                    <p className="text-sm text-gray-400">
+                      {c.author.username} •{" "}
+                      {new Date(c.created_at).toLocaleString()}
+                    </p>
+                    <p className="whitespace-pre-wrap mt-1">{c.content}</p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </ScrollArea>
+        </CardContent>
+      </Card>
     </div>
   );
 };

--- a/src/components/Posts.tsx
+++ b/src/components/Posts.tsx
@@ -1,56 +1,34 @@
-
-import { useState } from 'react';
-import { MessageSquare, Users, Bell } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchBoards, fetchPostsByBoard, PostSummary } from '@/lib/api';
+import CreatePostDialog from './CreatePostDialog';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import PostDetailContent from './PostDetailContent';
 
 const Posts = () => {
-  const [activeCategory, setActiveCategory] = useState('all');
-  
-  const categories = [
-    { id: 'all', label: '전체', count: 156 },
-    { id: 'general', label: '일반', count: 89 },
-    { id: 'tech', label: '기술', count: 34 },
-    { id: 'qa', label: 'Q&A', count: 33 },
-  ];
+  const [activeBoard, setActiveBoard] = useState<number | null>(null);
+  const [selectedPost, setSelectedPost] = useState<PostSummary | null>(null);
 
-  const posts = [
-    {
-      id: 1,
-      title: '새로운 커뮤니티 기능에 대한 의견을 들려주세요!',
-      content: '안녕하세요! 커뮤니티 운영진입니다. 새로운 기능들을 계획하고 있는데 여러분의 의견이 필요합니다...',
-      author: '운영진',
-      avatar: '🛡️',
-      time: '2시간 전',
-      likes: 24,
-      comments: 15,
-      category: 'general'
-    },
-    {
-      id: 2,
-      title: 'React 18의 새로운 기능들 정리',
-      content: 'React 18에서 추가된 Concurrent Features들에 대해 정리해보았습니다. Suspense, useTransition...',
-      author: '개발자김씨',
-      avatar: '👨‍💻',
-      time: '4시간 전',
-      likes: 45,
-      comments: 28,
-      category: 'tech'
-    },
-    {
-      id: 3,
-      title: '프로젝트 협업 도구 추천 부탁드립니다',
-      content: '팀 프로젝트를 진행하는데 좋은 협업 도구가 있을까요? 현재 Discord와 GitHub을 사용하고 있는데...',
-      author: '신입개발자',
-      avatar: '🌱',
-      time: '6시간 전',
-      likes: 12,
-      comments: 9,
-      category: 'qa'
-    },
-  ];
+  const boardsQuery = useQuery({
+    queryKey: ['boards'],
+    queryFn: fetchBoards,
+  });
 
-  const filteredPosts = activeCategory === 'all' 
-    ? posts 
-    : posts.filter(post => post.category === activeCategory);
+  const postsQuery = useQuery({
+    queryKey: ['posts', activeBoard],
+    queryFn: () => (activeBoard !== null ? fetchPostsByBoard(activeBoard) : Promise.resolve([])),
+    enabled: activeBoard !== null,
+  });
+
+  useEffect(() => {
+    if (!boardsQuery.isLoading && boardsQuery.data && activeBoard === null) {
+      const first = boardsQuery.data[0];
+      if (first) setActiveBoard(first.id);
+    }
+  }, [boardsQuery.isLoading, boardsQuery.data, activeBoard]);
+
+  const boards = boardsQuery.data ?? [];
+  const posts = postsQuery.data ?? [];
 
   return (
     <div className="p-6">
@@ -59,55 +37,66 @@ const Posts = () => {
           <h1 className="text-2xl font-bold">게시판</h1>
           <p className="text-gray-400 mt-1">커뮤니티 멤버들과 소통하세요</p>
         </div>
-        <button className="bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded-lg transition-colors">
-          새 글 작성
-        </button>
+        {activeBoard !== null && <CreatePostDialog boardId={activeBoard} />}
       </div>
 
       <div className="flex space-x-4 mb-6">
-        {categories.map((category) => (
+        {boardsQuery.isLoading && <span>Loading...</span>}
+        {boards.map((board) => (
           <button
-            key={category.id}
-            onClick={() => setActiveCategory(category.id)}
+            key={board.id}
+            onClick={() => setActiveBoard(board.id)}
             className={`px-4 py-2 rounded-lg transition-colors ${
-              activeCategory === category.id
+              activeBoard === board.id
                 ? 'bg-blue-600 text-white'
                 : 'bg-gray-800 text-gray-300 hover:bg-gray-700'
             }`}
           >
-            {category.label} ({category.count})
+            {board.name} ({board.posts})
           </button>
         ))}
       </div>
 
       <div className="space-y-4">
-        {filteredPosts.map((post) => (
-          <div key={post.id} className="bg-gray-800 rounded-lg p-6 hover:bg-gray-750 transition-colors cursor-pointer">
+        {postsQuery.isLoading && <p>Loading posts...</p>}
+        {!postsQuery.isLoading && posts.length === 0 && <p>게시물이 없습니다.</p>}
+        {posts.map((post) => (
+          <div
+            key={post.id}
+            className="bg-gray-800 rounded-lg p-6 hover:bg-gray-750 transition-colors cursor-pointer"
+            onClick={() => setSelectedPost(post)}
+          >
             <div className="flex items-start space-x-4">
-              <div className="text-2xl">{post.avatar}</div>
               <div className="flex-1">
                 <div className="flex items-center space-x-2 mb-2">
-                  <h3 className="font-semibold">{post.author}</h3>
+                  <h3 className="font-semibold">{post.author.username}</h3>
                   <span className="text-gray-400 text-sm">•</span>
-                  <span className="text-gray-400 text-sm">{post.time}</span>
+                  <span className="text-gray-400 text-sm">
+                    {new Date(post.created_at).toLocaleString()}
+                  </span>
                 </div>
                 <h2 className="text-lg font-medium mb-2">{post.title}</h2>
-                <p className="text-gray-300 mb-4">{post.content}</p>
-                <div className="flex items-center space-x-6 text-sm text-gray-400">
-                  <div className="flex items-center space-x-2">
-                    <Bell size={16} />
-                    <span>{post.likes}</span>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <MessageSquare size={16} />
-                    <span>{post.comments}</span>
-                  </div>
-                </div>
               </div>
             </div>
           </div>
         ))}
       </div>
+
+      <Dialog
+        open={selectedPost !== null}
+        onOpenChange={(open) => {
+          if (!open) setSelectedPost(null);
+        }}
+      >
+        <DialogContent className="max-w-3xl">
+          {selectedPost && (
+            <PostDetailContent
+              boardId={selectedPost.board_id}
+              postId={selectedPost.id}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 
-import { Home, MessageSquare, Users, Bell, Phone, User, LogOut, LogIn } from 'lucide-react';
+import { Home, MessageSquare, Users, Bell, Phone, User, LogOut, LogIn, MessageCircle } from 'lucide-react';
 import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AuthContext } from '@/context/AuthContext';
@@ -16,6 +16,7 @@ const Sidebar = ({ activeTab, setActiveTab }: SidebarProps) => {
   const menuItems = [
     { id: 'dashboard', icon: Home, label: '대시보드' },
     { id: 'posts', icon: MessageSquare, label: '게시판' },
+    { id: 'chat', icon: MessageCircle, label: '채팅' },
     { id: 'messages', icon: MessageSquare, label: 'DM' },
     { id: 'profile', icon: User, label: '프로필' },
     { id: 'notifications', icon: Bell, label: '알림' },

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,8 @@
 
-import { Home, MessageSquare, Users, Bell, Phone, User } from 'lucide-react';
+import { Home, MessageSquare, Users, Bell, Phone, User, LogOut, LogIn } from 'lucide-react';
+import { useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '@/context/AuthContext';
 
 interface SidebarProps {
   activeTab: string;
@@ -7,6 +10,9 @@ interface SidebarProps {
 }
 
 const Sidebar = ({ activeTab, setActiveTab }: SidebarProps) => {
+  const { logout, isAuthenticated } = useContext(AuthContext);
+  const navigate = useNavigate();
+
   const menuItems = [
     { id: 'dashboard', icon: Home, label: '대시보드' },
     { id: 'posts', icon: MessageSquare, label: '게시판' },
@@ -44,15 +50,37 @@ const Sidebar = ({ activeTab, setActiveTab }: SidebarProps) => {
       </nav>
       
       <div className="p-4 border-t border-gray-700">
-        <div className="flex items-center space-x-3">
-          <div className="w-8 h-8 bg-blue-600 rounded-full flex items-center justify-center">
-            <User size={16} />
-          </div>
-          <div>
-            <p className="text-sm font-medium">사용자</p>
-            <p className="text-xs text-gray-400">온라인</p>
-          </div>
-        </div>
+        {isAuthenticated ? (
+          <>
+            <div className="flex items-center space-x-3 mb-2">
+              <div className="w-8 h-8 bg-blue-600 rounded-full flex items-center justify-center">
+                <User size={16} />
+              </div>
+              <div>
+                <p className="text-sm font-medium">사용자</p>
+                <p className="text-xs text-gray-400">온라인</p>
+              </div>
+            </div>
+            <button
+              onClick={() => {
+                logout();
+                navigate('/login');
+              }}
+              className="flex items-center space-x-2 text-red-400 hover:text-red-300 text-sm"
+            >
+              <LogOut size={16} />
+              <span>로그아웃</span>
+            </button>
+          </>
+        ) : (
+          <button
+            onClick={() => navigate('/login')}
+            className="flex items-center space-x-2 text-blue-400 hover:text-blue-300 text-sm"
+          >
+            <LogIn size={16} />
+            <span>로그인</span>
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+export type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base text-foreground ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className
         )}
         ref={ref}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/src/context/AuthContext.ts
+++ b/src/context/AuthContext.ts
@@ -1,0 +1,18 @@
+import { createContext } from 'react';
+import type { LoginPayload } from '@/lib/api';
+
+export interface AuthContextValue {
+  accessToken: string | null;
+  refreshToken: string | null;
+  isAuthenticated: boolean;
+  login: (payload: LoginPayload) => Promise<void>;
+  logout: () => void;
+}
+
+export const AuthContext = createContext<AuthContextValue>({
+  accessToken: null,
+  refreshToken: null,
+  isAuthenticated: false,
+  login: async () => {},
+  logout: () => {},
+});

--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -1,0 +1,53 @@
+import { useState, useEffect, ReactNode } from 'react';
+import type { LoginPayload, LoginResponse } from '@/lib/api';
+import { login as loginRequest } from '@/lib/api';
+import { AuthContext } from './AuthContext';
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [refreshToken, setRefreshToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    const access = localStorage.getItem('access_token');
+    const refresh = localStorage.getItem('refresh_token');
+    if (access && refresh) {
+      setAccessToken(access);
+      setRefreshToken(refresh);
+    }
+  }, []);
+
+  const saveTokens = (data: LoginResponse) => {
+    setAccessToken(data.access_token);
+    setRefreshToken(data.refresh_token);
+    localStorage.setItem('access_token', data.access_token);
+    localStorage.setItem('refresh_token', data.refresh_token);
+  };
+
+  const login = async (payload: LoginPayload) => {
+    const data = await loginRequest(payload);
+    saveTokens(data);
+  };
+
+  const logout = () => {
+    setAccessToken(null);
+    setRefreshToken(null);
+    localStorage.removeItem('access_token');
+    localStorage.removeItem('refresh_token');
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{
+        accessToken,
+        refreshToken,
+        isAuthenticated: !!accessToken,
+        login,
+        logout,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export default AuthProvider;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,225 @@
+const API_BASE_URL = import.meta.env.VITE_API_URL ?? '/api/v1';
+
+export interface LoginPayload {
+  username: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  access_token: string;
+  refresh_token: string;
+}
+
+export async function login(payload: LoginPayload): Promise<LoginResponse> {
+  const response = await fetch(`${API_BASE_URL}/auth/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    let message = 'Failed to login';
+    try {
+      const data = await response.json();
+      message = data.detail ?? message;
+    } catch {
+      // ignore
+    }
+    throw new Error(message);
+  }
+
+  return response.json();
+}
+
+export interface SignupPayload {
+  username: string;
+  firstname: string;
+  lastname: string;
+  email: string;
+  password: string;
+}
+
+export async function signup(payload: SignupPayload): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/auth/signup`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    let message = 'Failed to register';
+    try {
+      const data = await response.json();
+      message = data.detail ?? message;
+    } catch {
+      // ignore
+    }
+    throw new Error(message);
+  }
+}
+
+export interface RefreshPayload {
+  refresh_token: string;
+  token_type: 'bearer';
+}
+
+export async function refreshTokens(
+  payload: RefreshPayload,
+): Promise<LoginResponse> {
+  const response = await fetch(`${API_BASE_URL}/auth/refresh`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    let message = 'Failed to refresh token';
+    try {
+      const data = await response.json();
+      message = data.detail ?? message;
+    } catch {
+      // ignore
+    }
+    throw new Error(message);
+  }
+
+  return response.json();
+}
+
+export interface Board {
+  id: number;
+  name: string;
+  description: string;
+  posts: number;
+  created_at: string;
+}
+
+export async function fetchBoards(): Promise<Board[]> {
+  const response = await fetch(`${API_BASE_URL}/boards/all_boards`);
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch boards');
+  }
+
+  return response.json();
+}
+
+export interface PostSummary {
+  id: number;
+  board_id: number;
+  title: string;
+  author: {
+    id: number;
+    username: string;
+  };
+  created_at: string;
+}
+
+export async function fetchPostsByBoard(
+  boardId: number,
+  params?: { page?: number; size?: number },
+): Promise<PostSummary[]> {
+  const search = new URLSearchParams();
+  if (params?.page) search.append('page', String(params.page));
+  if (params?.size) search.append('size', String(params.size));
+  const query = search.toString();
+  const url = `${API_BASE_URL}/posts/boards/${boardId}/posts${query ? `?${query}` : ''}`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch posts');
+  }
+
+  return response.json();
+}
+
+export interface CreatePostPayload {
+  title: string;
+  content: string;
+  board_id: number;
+}
+
+export interface FileMeta {
+  id: number;
+  filename?: string;
+}
+
+export interface Post extends PostSummary {
+  content: string;
+  files: FileMeta[];
+  updated_at: string;
+}
+
+export async function createPost(
+  boardId: number,
+  payload: CreatePostPayload,
+  token?: string,
+): Promise<Post> {
+  const response = await fetch(
+    `${API_BASE_URL}/posts/boards/${boardId}/posts`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(payload),
+    },
+  );
+
+  if (!response.ok) {
+    let message = 'Failed to create post';
+    try {
+      const data = await response.json();
+      message = data.detail ?? message;
+    } catch {
+      // ignore
+    }
+    throw new Error(message);
+  }
+
+  return response.json();
+}
+
+export async function fetchPost(
+  boardId: number,
+  postId: number,
+): Promise<Post> {
+  const response = await fetch(
+    `${API_BASE_URL}/posts/boards/${boardId}/posts/${postId}`,
+  );
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch post');
+  }
+
+  return response.json();
+}
+
+export interface Comment {
+  id: number;
+  content: string;
+  depth: number;
+  parent_id: number | null;
+  author: {
+    id: number;
+    username: string;
+  };
+  created_at: string;
+}
+
+export async function fetchComments(postId: number): Promise<Comment[]> {
+  const response = await fetch(`${API_BASE_URL}/posts/${postId}/comments`);
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch comments');
+  }
+
+  return response.json();
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -223,3 +223,35 @@ export async function fetchComments(postId: number): Promise<Comment[]> {
 
   return response.json();
 }
+
+export interface CreateCommentPayload {
+  content: string;
+}
+
+export async function createComment(
+  postId: number,
+  payload: CreateCommentPayload,
+  token?: string,
+): Promise<Comment> {
+  const response = await fetch(`${API_BASE_URL}/posts/${postId}/comments`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    let message = 'Failed to create comment';
+    try {
+      const data = await response.json();
+      message = data.detail ?? message;
+    } catch {
+      // ignore
+    }
+    throw new Error(message);
+  }
+
+  return response.json();
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,6 +4,7 @@ import Sidebar from '@/components/Sidebar';
 import Dashboard from '@/components/Dashboard';
 import Posts from '@/components/Posts';
 import DirectMessages from '@/components/DirectMessages';
+import Chat from '@/components/Chat';
 import Profile from '@/components/Profile';
 import Notifications from '@/components/Notifications';
 import VoiceCall from '@/components/VoiceCall';
@@ -19,6 +20,8 @@ const Index = () => {
         return <Posts />;
       case 'messages':
         return <DirectMessages />;
+      case 'chat':
+        return <Chat />;
       case 'profile':
         return <Profile />;
       case 'notifications':

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -18,8 +18,8 @@ import { Button } from '@/components/ui/button';
 import { toast } from '@/components/ui/sonner';
 
 const schema = z.object({
-  username: z.string().min(1, 'Enter username'),
-  password: z.string().min(1, 'Enter password'),
+  username: z.string().min(1, '아이디를 입력해주세요'),
+  password: z.string().min(1, '비밀번호를 입력해주세요'),
 });
 
 type FormValues = z.infer<typeof schema>;
@@ -47,7 +47,7 @@ const Login = () => {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-900 text-white">
       <div className="w-full max-w-sm bg-gray-800 p-6 rounded-md shadow border border-gray-700">
-        <h1 className="text-xl font-bold mb-4">Login</h1>
+        <h1 className="text-xl font-bold mb-4">로그인</h1>
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
             <FormField
@@ -55,7 +55,7 @@ const Login = () => {
               name="username"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Username</FormLabel>
+                  <FormLabel>아이디</FormLabel>
                   <FormControl>
                     <Input {...field} />
                   </FormControl>
@@ -68,7 +68,7 @@ const Login = () => {
               name="password"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Password</FormLabel>
+                  <FormLabel>비밀번호</FormLabel>
                   <FormControl>
                     <Input type="password" {...field} />
                   </FormControl>
@@ -77,12 +77,12 @@ const Login = () => {
               )}
             />
             <Button type="submit" className="w-full" disabled={mutation.isPending}>
-              {mutation.isPending ? 'Logging in...' : 'Login'}
+              {mutation.isPending ? '로그인 중...' : '로그인'}
             </Button>
             <p className="text-sm text-center">
-              Don't have an account?{' '}
+              계정이 없으신가요?{' '}
               <Link to="/register" className="text-blue-400 hover:text-blue-300 underline">
-                Register
+                회원가입
               </Link>
             </p>
           </form>

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -1,0 +1,22 @@
+import { useParams, Link } from 'react-router-dom';
+import PostDetailContent from '@/components/PostDetailContent';
+
+const PostDetail = () => {
+  const { boardId, postId } = useParams<{ boardId: string; postId: string }>();
+
+  if (!boardId || !postId) {
+    return <div className="p-6">Invalid post</div>;
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <Link to="/" className="text-blue-400 hover:underline">
+        &larr; Back
+      </Link>
+      <PostDetailContent boardId={Number(boardId)} postId={Number(postId)} />
+    </div>
+  );
+};
+
+export default PostDetail;
+

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,10 +1,9 @@
-import { useNavigate, Link } from 'react-router-dom';
-import { useContext } from 'react';
-import { AuthContext } from '@/context/AuthContext';
+import { useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation } from '@tanstack/react-query';
 import * as z from 'zod';
+import { signup as registerUser } from '@/lib/api';
 import {
   Form,
   FormField,
@@ -19,23 +18,32 @@ import { toast } from '@/components/ui/sonner';
 
 const schema = z.object({
   username: z.string().min(1, 'Enter username'),
+  firstname: z.string().min(1, 'Enter first name'),
+  lastname: z.string().min(1, 'Enter last name'),
+  email: z.string().email('Invalid email'),
   password: z.string().min(1, 'Enter password'),
 });
 
 type FormValues = z.infer<typeof schema>;
 
-const Login = () => {
+const Register = () => {
   const navigate = useNavigate();
-  const auth = useContext(AuthContext);
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
-    defaultValues: { username: '', password: '' },
+    defaultValues: {
+      username: '',
+      firstname: '',
+      lastname: '',
+      email: '',
+      password: '',
+    },
   });
 
   const mutation = useMutation({
-    mutationFn: auth.login,
+    mutationFn: registerUser,
     onSuccess: () => {
-      navigate('/');
+      toast.success('Registration successful');
+      navigate('/login');
     },
     onError: (err: Error) => toast.error(err.message),
   });
@@ -47,7 +55,7 @@ const Login = () => {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-900 text-white">
       <div className="w-full max-w-sm bg-gray-800 p-6 rounded-md shadow border border-gray-700">
-        <h1 className="text-xl font-bold mb-4">Login</h1>
+        <h1 className="text-xl font-bold mb-4">Register</h1>
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
             <FormField
@@ -58,6 +66,45 @@ const Login = () => {
                   <FormLabel>Username</FormLabel>
                   <FormControl>
                     <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="firstname"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>First name</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="lastname"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Last name</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input type="email" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -77,14 +124,8 @@ const Login = () => {
               )}
             />
             <Button type="submit" className="w-full" disabled={mutation.isPending}>
-              {mutation.isPending ? 'Logging in...' : 'Login'}
+              {mutation.isPending ? 'Registering...' : 'Register'}
             </Button>
-            <p className="text-sm text-center">
-              Don't have an account?{' '}
-              <Link to="/register" className="text-blue-400 hover:text-blue-300 underline">
-                Register
-              </Link>
-            </p>
           </form>
         </Form>
       </div>
@@ -92,4 +133,4 @@ const Login = () => {
   );
 };
 
-export default Login;
+export default Register;

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -17,11 +17,11 @@ import { Button } from '@/components/ui/button';
 import { toast } from '@/components/ui/sonner';
 
 const schema = z.object({
-  username: z.string().min(1, 'Enter username'),
-  firstname: z.string().min(1, 'Enter first name'),
-  lastname: z.string().min(1, 'Enter last name'),
-  email: z.string().email('Invalid email'),
-  password: z.string().min(1, 'Enter password'),
+  username: z.string().min(1, '아이디를 입력해주세요'),
+  firstname: z.string().min(1, '이름을 입력해주세요'),
+  lastname: z.string().min(1, '성을 입력해주세요'),
+  email: z.string().email('올바른 이메일 형식이 아닙니다'),
+  password: z.string().min(1, '비밀번호를 입력해주세요'),
 });
 
 type FormValues = z.infer<typeof schema>;
@@ -42,7 +42,7 @@ const Register = () => {
   const mutation = useMutation({
     mutationFn: registerUser,
     onSuccess: () => {
-      toast.success('Registration successful');
+      toast.success('회원가입이 완료되었습니다');
       navigate('/login');
     },
     onError: (err: Error) => toast.error(err.message),
@@ -55,7 +55,7 @@ const Register = () => {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-900 text-white">
       <div className="w-full max-w-sm bg-gray-800 p-6 rounded-md shadow border border-gray-700">
-        <h1 className="text-xl font-bold mb-4">Register</h1>
+        <h1 className="text-xl font-bold mb-4">회원가입</h1>
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
             <FormField
@@ -63,7 +63,7 @@ const Register = () => {
               name="username"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Username</FormLabel>
+                  <FormLabel>아이디</FormLabel>
                   <FormControl>
                     <Input {...field} />
                   </FormControl>
@@ -76,7 +76,7 @@ const Register = () => {
               name="firstname"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>First name</FormLabel>
+                  <FormLabel>이름</FormLabel>
                   <FormControl>
                     <Input {...field} />
                   </FormControl>
@@ -89,7 +89,7 @@ const Register = () => {
               name="lastname"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Last name</FormLabel>
+                  <FormLabel>성</FormLabel>
                   <FormControl>
                     <Input {...field} />
                   </FormControl>
@@ -102,7 +102,7 @@ const Register = () => {
               name="email"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Email</FormLabel>
+                  <FormLabel>이메일</FormLabel>
                   <FormControl>
                     <Input type="email" {...field} />
                   </FormControl>
@@ -115,7 +115,7 @@ const Register = () => {
               name="password"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Password</FormLabel>
+                  <FormLabel>비밀번호</FormLabel>
                   <FormControl>
                     <Input type="password" {...field} />
                   </FormControl>
@@ -124,7 +124,7 @@ const Register = () => {
               )}
             />
             <Button type="submit" className="w-full" disabled={mutation.isPending}>
-              {mutation.isPending ? 'Registering...' : 'Register'}
+              {mutation.isPending ? '가입 중...' : '회원가입'}
             </Button>
           </form>
         </Form>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -92,5 +93,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+       plugins: [animatePlugin],
 } satisfies Config;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,12 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: {
+      "/api": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+      },
+    },
   },
   plugins: [
     react(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig(({ mode }) => ({
       "/api": {
         target: "http://localhost:8000",
         changeOrigin: true,
+        ws: true,
       },
     },
   },


### PR DESCRIPTION
## Summary
- extract core post detail view to `PostDetailContent`
- render post details inside a dialog when selecting a post
- keep a slim `PostDetail` page that reuses the shared component

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685003772ca0832e8b93ee13d672feef